### PR TITLE
Add ability to bind to particular interface rather than just port

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ I built this because I needed a way to "tap" production traffic and shoot it at 
 
 ```
 npm install -g duplicator
-duplicator -f localhost:80 -d localhost:3000 -p 8080
+duplicator -f localhost:80 -d localhost:3000 -p 8080 [-i 127.0.0.1]
 ```
 
 * forward all traffic to `localhost:80`
 * duplicate all traffic to `localhost:3000`, ignoring responses
 * listen on port `8080`
+* if -i is specified only listen to incoming traffic for ip address 127.0.0.1
 
 Note: the cli automatically uses the cluster API to run several workers to handle connections, and restart workers if they die.
 
@@ -27,7 +28,7 @@ var duplicator = require('duplicator')
 var server = duplicator(function(connection, forward, duplicate) {
   forward('localhost:80')
   duplicate('localhost:3000')
-}).listen(8080)
+}).listen(8080, ["127.0.0.1"])
 ```
 
 # reference

--- a/bin/duplicator
+++ b/bin/duplicator
@@ -48,7 +48,7 @@ if (cluster.isMaster) {
         }
 
         if (!argv.p) throw 'You must specify a port, either via the -p option or' +
-          'in the PORT environment variable or'
+          'in the PORT environment variable'
 
         if (!argv.f) throw 'You must specify a host to forward to with -f option'
       })

--- a/bin/duplicator
+++ b/bin/duplicator
@@ -22,6 +22,10 @@ if (cluster.isMaster) {
         , describe: 'port to listen on, defaults to PORT'
         , 'default': process.env['PORT']
         })
+      .options('i',
+        { alias: 'interface'
+        , describe: 'ip address to listen on, defaults to INADDR_ANY'
+        })
       .options('f',
         { alias: 'forward'
         , describe: 'host to forward to'
@@ -44,7 +48,7 @@ if (cluster.isMaster) {
         }
 
         if (!argv.p) throw 'You must specify a port, either via the -p option or' +
-          'in the PORT environment variable'
+          'in the PORT environment variable or'
 
         if (!argv.f) throw 'You must specify a host to forward to with -f option'
       })
@@ -52,6 +56,7 @@ if (cluster.isMaster) {
 
   function serverInfo() {
     log("Listening on port:", argv.p)
+    if (argv.i) log("Listening on interface:", argv.i)
     if (argv.f) log("Forwarding to:", argv.f)
     if (argv.d) log("Duplicating to:", argv.d)
     if (argv.r) log("Sample rate:", argv.r)
@@ -89,6 +94,6 @@ if (cluster.isMaster) {
       if (argv.f) forward(argv.f)
       if (argv.d) duplicate(argv.d, argv.r)
     })
-    server.listen(argv.p)
+    server.listen(argv.p, argv.i)
   })
 }


### PR DESCRIPTION
I needed to the ability to bind only a particular interface on a machine so I added it in. I'm happy to change the option names etc if you think there is a better one (I spent a while thinking about this but nothing very obvious came up)
