### PR TITLE
use bufferedstream instead of morestreams

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var net = require('net')
-  , BufferedStream = require('morestreams').BufferedStream
+  , BufferedStream = require('bufferedstream')
 
 var ERR_MSG =
   { MULTIPLE_FWD:

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Isaac Wolkerstorfer <i@agnoster.net> (http://agnoster.net/)",
   "license": "MIT",
   "dependencies": {
-    "optimist": "~0.3.5",
+    "bufferedstream": "^3.1.0",
     "colors": "0.6.0-1",
-    "morestreams": "~0.1.1"
+    "optimist": "~0.3.5"
   },
   "devDependencies": {
     "tap": "~0.3.1"


### PR DESCRIPTION
We'd like to use duplicator, but our automated scripts that check for compatible licenses detected that morestreams wasn't actually tagged with an open source license.

I opened https://github.com/mikeal/morestreams/issues/10 but that hasn't yet been addressed by the author.

However, it looks like https://github.com/mjackson/bufferedstream is a robust implementation of a buffered stream that is MIT licensed, and it looks like a drop-in and improved replacement for morestreams.

This branch passes the tests run with `./node_modules/.bin/tap  test/index.test.js test/clients/* test/servers/*`
