### PR TITLE
Fixed "BufferedStream is already ended" error when duplicate server is down.

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,7 @@ function duplicator(cb) {
           console.error(ERR_MSG.FWD_CONN_ERROR, err)
           client.end()
         }
-        if (client.connected && !buffer.ended)
-          buffer.end()
+        if (client.connected && !buffer.ended) buffer.end()
         return
       }
       if (forwardResponse) connection.pipe(client)

--- a/index.js
+++ b/index.js
@@ -95,7 +95,8 @@ function duplicator(cb) {
           console.error(ERR_MSG.FWD_CONN_ERROR, err)
           client.end()
         }
-        buffer.end()
+        if (client.connected && !buffer.ended)
+          buffer.end()
         return
       }
       if (forwardResponse) connection.pipe(client)


### PR DESCRIPTION
Fixed the following error when duplicate server is down.
"BufferedStream is already ended"